### PR TITLE
Add support for multiple btfhub-archive repositories to btfgen script

### DIFF
--- a/script/btfgen
+++ b/script/btfgen
@@ -13,8 +13,10 @@ usage() {
       Create reduced version of BTF files to be embedded within the tools executables
 
 	  ${script_name} [fetch]
-      fetch btfhub-archive from github and save to DIR
+      fetch btfhub-archive from REPO and save to DIR
       DIR default is "${HOME}/.cache/eunomia/btfhub" or you can set "\$BTFHUB_CACHE" to override
+      REPO default is "https://github.com/aquasecurity/btfhub-archive" or you can set "\$BTFHUB_REPO"
+      to override; multiple repositories are separated by commas (,)
 
 	Options:
 	  btfgen options:
@@ -24,14 +26,27 @@ usage() {
 }
 
 fetch() {
-  if ! command -v git &> /dev/null; then echo "Error: git is not installed."; exit 1; fi
   if [ -d "$BTFHUB_CACHE_DIR" ]; then
     echo "BTFHUB_CACHE_DIR does exist, skip fetch"
     return
   fi
 
-  mkdir -p ${BTFHUB_CACHE_DIR}
-  git clone --depth 1 ${BTFHUB_REPO_URL} ${BTFHUB_CACHE_DIR}/btfhub-archive
+  if ! command -v git &> /dev/null; then echo "Error: git is not installed."; exit 1; fi
+  if ! command -v rsync &> /dev/null; then echo "Error: rsync is not installed."; exit 1; fi
+  
+  local repos repo repo_dir
+  IFS=',' read -r -a repos <<< "$BTFHUB_REPO_URL"
+  for repo in "${repos[@]}"; do
+    repo_dir="$BTFHUB_CACHE_DIR/btfhub-archive-repos/${repo//[^A-Za-z0-9._-]/_}/"
+    mkdir -p "$repo_dir"
+    git clone --depth 1 "$repo" "$repo_dir"
+    rsync -av --quiet --ignore-existing \
+      --exclude 'LICENSE' \
+      --exclude 'README.md' \
+      --exclude '.gitignore' \
+      --exclude '.git' \
+      "$repo_dir" "$BTFHUB_CACHE_DIR/btfhub-archive/"
+  done
 }
 
 btfgen() {
@@ -58,18 +73,15 @@ btfgen() {
  
   dir=$(pwd)
 
-  find $BTFHUB_CACHE_DIR -name "*.tar.xz" | \
+  find $BTFHUB_CACHE_DIR -name "*.tar.xz" -not -path "$BTFHUB_CACHE_DIR/btfhub-archive-repos/*" | \
   xargs -P 8 -I fileName sh -c 'tar xfJ "fileName" -C "$(dirname "fileName")"'
-  find $BTFHUB_CACHE_DIR -name "*.btf" | \
+  find $BTFHUB_CACHE_DIR -name "*.btf" -not -path "$BTFHUB_CACHE_DIR/btfhub-archive-repos/*" | \
   xargs -P 8 -I fileName sh -c 'bpftool gen min_core_btf "fileName" "fileName" '$file''
 
   if [ -n "$json" ]; then cp $json $BTFHUB_CACHE_DIR; fi
 
   cd $BTFHUB_CACHE_DIR && tar \
-    --exclude="./btfhub-archive/LICENSE" \
-    --exclude="./btfhub-archive/README.md" \
-    --exclude="./btfhub-archive/.gitignore" \
-    --exclude="./btfhub-archive/.git" \
+    --exclude="./btfhub-archive-repos" \
     --exclude="*.xz" \
     -czf $dir/$output .
 }


### PR DESCRIPTION
## Description

This PR adds support for multiple btfhub-archive repositories to the `btfgen` script. This feature can be helpful if the user would like to include BTFs for distributions (e.g. openEuler) that the official [aquasecurity/btfhub-archive](https://github.com/aquasecurity/btfhub-archive) does not support in the packaged TAR file.

Once this PR is merged, users will be able to provide a comma-separated list of Git repositories to clone from when running `btfgen fetch`, like:

```bash
BTFHUB_REPO=https://github.com/aquasecurity/btfhub-archive,https://github.com/eunomia-bpf/btfhub-archive ./script/btfgen fetch
```

Specified repositories will be first cloned into `$BTFHUB_CACHE_DIR/btfhub-archive-repos` and then copied and mixed in `$BTFHUB_CACHE_DIR/btfhub-archive`. If more than one repository has the same file, the one that appears first in the list takes precedence.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Changes in this PR can be verified with the following steps:

1. Apply the following diff to [`example/c/Makefile`](https://github.com/eunomia-bpf/bpf-compatible/blob/main/example/c/Makefile):
```diff
diff --git a/example/c/Makefile b/example/c/Makefile
index 6a40613..79a9a3a 100644
--- a/example/c/Makefile
+++ b/example/c/Makefile
@@ -131,7 +131,7 @@ $(OUTPUT)/libbpf_compatible.a:
        cp ../../bpf-compatible-sys/libbpf_compatible.a $(OUTPUT)
 
 $(OUTPUT)/btfhub-cache:
-       BTFHUB_REPO=https://github.com/eunomia-bpf/btfhub-archive \
+       BTFHUB_REPO=https://github.com/eunomia-bpf/btfhub-archive,https://github.com/YangHanlin/btfhub-archive \
        BTFHUB_CACHE=$(OUTPUT)/btfhub-cache \
        ../../script/btfgen fetch
```
2. Run `make`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
